### PR TITLE
Add new schema fields

### DIFF
--- a/lib/telemetry.rb
+++ b/lib/telemetry.rb
@@ -5,10 +5,15 @@ require "telemetry/session"
 require "telemetry/version"
 
 class Telemetry
-  attr_accessor :product, :origin
-  def initialize(product: nil, origin: "command-line")
+  attr_accessor :product, :origin, :product_version, :install_context
+  def initialize(product: nil, origin: "command-line",
+                 product_version: "0.0.0",
+                 install_context: "omnibus")
+    # Reference: https://github.com/chef/es-telemetry-pipeline/blob/0730c1e2605624a50d34bab6d036b73c31e0ab0e/schema/event.schema.json#L77
     @product = product
     @origin = origin
+    @product_version = product_version
+    @install_context = install_context # Valid: habitat, omnibus
   end
 
   def deliver(data = {})
@@ -19,7 +24,8 @@ class Telemetry
   end
 
   def event
-    @event ||= Event.new(product, session, origin)
+    @event ||= Event.new(product, session, origin,
+                         install_context, product_version)
   end
 
   def session

--- a/lib/telemetry/event.rb
+++ b/lib/telemetry/event.rb
@@ -9,11 +9,15 @@ class Telemetry
       type:  "track",
     }.freeze
 
-    attr_reader :session, :product, :origin
-    def initialize(product, session, origin = "command-line")
+    attr_reader :session, :product, :origin,
+      :product_version, :install_context
+    def initialize(product, session, origin = "command-line",
+                   install_context = "omnibus", product_version = "0.0.0")
       @product = product
       @session = session
       @origin = origin
+      @product_version = product_version
+      @install_context = install_context
     end
 
     def prepare(event)
@@ -24,6 +28,8 @@ class Telemetry
         b[:session_id] = session.id
         b[:origin] = origin
         b[:product] = product
+        b[:product_version] = product_version
+        b[:install_context] = install_context
         b[:timestamp] = time
         b[:payload] = event
       end

--- a/spec/decision_spec.rb
+++ b/spec/decision_spec.rb
@@ -1,7 +1,7 @@
 require "spec_helper"
 
 RSpec.describe Telemetry::Decision do
-  let (:env) { {} }
+  let(:env) { {} }
   let(:env_pwd) { "/path/to/cwd" }
   let(:home) { "/Users/chef_user" }
 

--- a/spec/event_spec.rb
+++ b/spec/event_spec.rb
@@ -2,6 +2,8 @@ require "spec_helper"
 
 RSpec.describe Telemetry::Event do
   let(:product) { "unit" }
+  let(:product_version) { "1.0.0" }
+  let(:install_context) { "omnibus" }
   let(:session_id) { "A-NEW-UUID" }
   let(:session) { double("Session", id: session_id) }
   let(:origin) { "rspec" }
@@ -21,7 +23,7 @@ RSpec.describe Telemetry::Event do
 
   describe "#prepare" do
     subject do
-      e = Telemetry::Event.new(product, session, origin)
+      e = Telemetry::Event.new(product, session, origin, install_context, product_version)
       e.prepare(event)
     end
 


### PR DESCRIPTION
This adds the new telemetry fields 'product_version'
and 'install_context' to the Telemetry and Event
classes.  These have recently been added to the telemetry
pipeline schema:

https://github.com/chef/es-telemetry-pipeline/blob/0730c1e2605624a50d34bab6d036b73c31e0ab0e/schema/event.schema.json#L77