### PR TITLE
Use 'class' instead of 'module' for "Chef".

### DIFF
--- a/lib/chef/telemeter.rb
+++ b/lib/chef/telemeter.rb
@@ -24,7 +24,7 @@ require "digest/sha1"
 require "securerandom"
 require "yaml"
 
-module Chef
+class Chef
   # This definites the Telemeter interface. Implementation thoughts for
   # when we unstub it:
   # - let's track the call sequence; most of our calls will be nested inside

--- a/lib/chef/telemeter/sender.rb
+++ b/lib/chef/telemeter/sender.rb
@@ -19,7 +19,7 @@ require "chef/telemetry"
 require "chef/telemeter"
 require "logger"
 
-module Chef
+class Chef
   class Telemeter
     logger = ::Logger.new(STDERR) # TODO: maybe switch to file, maybe switch to mixlib
     logger.level = Logger::ERROR

--- a/lib/chef/telemetry.rb
+++ b/lib/chef/telemetry.rb
@@ -4,7 +4,7 @@ require "chef/telemetry/event"
 require "chef/telemetry/session"
 require "chef/telemetry/version"
 
-module Chef
+class Chef
   class Telemetry
     attr_accessor :product, :origin, :product_version, :install_context
     def initialize(product: nil, origin: "command-line",

--- a/lib/chef/telemetry/client.rb
+++ b/lib/chef/telemetry/client.rb
@@ -1,7 +1,7 @@
 require "http"
 require "concurrent"
 
-module Chef
+class Chef
   class Telemetry
     class Client
       include Concurrent::Async

--- a/lib/chef/telemetry/decision.rb
+++ b/lib/chef/telemetry/decision.rb
@@ -2,7 +2,7 @@ require "chef-config/path_helper"
 require "chef-config/windows"
 
 # Decision allows us to inspect whether the user has made a decision to opt in or opt out of telemetry.
-module Chef
+class Chef
   class Telemetry
     module Decision
       OPT_OUT_FILE = "telemetry_opt_out".freeze

--- a/lib/chef/telemetry/event.rb
+++ b/lib/chef/telemetry/event.rb
@@ -1,4 +1,4 @@
-module Chef
+class Chef
   class Telemetry
     class Event
 

--- a/lib/chef/telemetry/session.rb
+++ b/lib/chef/telemetry/session.rb
@@ -1,7 +1,7 @@
 require "securerandom"
 require "chef-config/path_helper"
 
-module Chef
+class Chef
   class Telemetry
     class Session
       def initialize

--- a/lib/chef/telemetry/version.rb
+++ b/lib/chef/telemetry/version.rb
@@ -1,4 +1,4 @@
-module Chef
+class Chef
   class Telemetry
     VERSION = "1.0.0".freeze
   end


### PR DESCRIPTION
This prevents conflicts when used where the `chef` gem is pulled in,
because `chef` has `Chef` defined it as a class.

Signed-off-by: Marc A. Paradise <marc.paradise@gmail.com>
