### PR TITLE
Use require_relative to speed up requires

### DIFF
--- a/.expeditor/verify.pipeline.yml
+++ b/.expeditor/verify.pipeline.yml
@@ -40,7 +40,7 @@ steps:
   expeditor:
     executor:
       docker:
-        image: ruby:2.7-rc
+        image: ruby:2.7-buster
 
 - label: run-specs-windows
   command:

--- a/.github/lock.yml
+++ b/.github/lock.yml
@@ -1,1 +1,0 @@
-daysUntilLock: 60

--- a/lib/chef/telemeter.rb
+++ b/lib/chef/telemeter.rb
@@ -15,7 +15,7 @@
 # limitations under the License.
 #
 
-require "chef/telemetry/version"
+require_relative "telemetry/version"
 require "benchmark"
 require "forwardable"
 require "singleton"
@@ -51,13 +51,13 @@ class Chef
       # :dev_mode # false, not required
       config[:dev_mode] ||= false
       config[:enabled] ||= false
-      require "chef/telemeter/sender"
+      require_relative "telemeter/sender"
       @config = config
       Sender.start_upload_thread(config)
     end
 
     def enabled?
-      require "chef/telemetry/decision"
+      require_relative "telemetry/decision"
       config[:enabled] && !Telemetry::Decision.env_opt_out?
     end
 

--- a/lib/chef/telemeter/sender.rb
+++ b/lib/chef/telemeter/sender.rb
@@ -15,8 +15,8 @@
 # limitations under the License.
 #
 
-require "chef/telemetry"
-require "chef/telemeter"
+require_relative "../telemetry"
+require_relative "../telemeter"
 require "logger"
 
 class Chef

--- a/lib/chef/telemetry.rb
+++ b/lib/chef/telemetry.rb
@@ -1,8 +1,8 @@
-require "chef/telemetry/client"
-require "chef/telemetry/decision"
-require "chef/telemetry/event"
-require "chef/telemetry/session"
-require "chef/telemetry/version"
+require_relative "telemetry/client"
+require_relative "telemetry/decision"
+require_relative "telemetry/event"
+require_relative "telemetry/session"
+require_relative "telemetry/version"
 
 class Chef
   class Telemetry


### PR DESCRIPTION
require_relative is faster than require. Also switch to the final build for Ruby 2.7 for testing and nuke the lock config we're not using.

Signed-off-by: Tim Smith <tsmith@chef.io>