### PR TITLE
Upgrade http dependency

### DIFF
--- a/chef-telemetry.gemspec
+++ b/chef-telemetry.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_development_dependency "bundler"
-  spec.add_dependency "http", "~> 2.2"
+  spec.add_dependency "http", "~> 4"
   spec.add_dependency "ffi-yajl", "~> 2.2"
   spec.add_dependency "concurrent-ruby", "~> 1.0"
   spec.add_dependency "chef-config"


### PR DESCRIPTION
Upgrade http gem to a more recent version.

## Description
Other gems depend on this to be up to date

## Related Issue
https://github.com/chef/chef-telemetry/issues/29

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
