### PR TITLE
Directly address HTTP class

### DIFF
--- a/lib/chef/telemetry/client.rb
+++ b/lib/chef/telemetry/client.rb
@@ -11,7 +11,7 @@ class Chef
       attr_reader :http
       def initialize(endpoint = TELEMETRY_ENDPOINT)
         super()
-        @http = HTTP.persistent(endpoint)
+        @http = ::HTTP.persistent(endpoint)
       end
 
       def fire(event)


### PR DESCRIPTION
## Description
There is a Chef::HTTP class so this resolves the ambiguity by directly
calling ::HTTP

Discovered by running tests for chef-apply

## Related Issue
https://github.com/chef/chef-apply/pull/130

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
