### PR TITLE
Use Net::HTTP instead of HTTP

### DIFF
--- a/chef-telemetry.gemspec
+++ b/chef-telemetry.gemspec
@@ -15,7 +15,6 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_development_dependency "bundler"
-  spec.add_dependency "http", "~> 4"
   spec.add_dependency "ffi-yajl", "~> 2.2"
   spec.add_dependency "concurrent-ruby", "~> 1.0"
   spec.add_dependency "chef-config"

--- a/lib/chef/telemetry/client.rb
+++ b/lib/chef/telemetry/client.rb
@@ -1,4 +1,5 @@
-require "http"
+require "net/http"
+require "json"
 require "concurrent"
 
 class Chef
@@ -11,11 +12,16 @@ class Chef
       attr_reader :http
       def initialize(endpoint = TELEMETRY_ENDPOINT)
         super()
-        @http = ::HTTP.persistent(endpoint)
+        @http = Net::HTTP.new(endpoint)
+        @http.start
       end
 
       def fire(event)
-        http.post("/events", json: event).flush
+        req = Net::HTTP::Post.new("/events")
+        req["Content-Type"] = "application/json"
+        req.body = JSON.dump(event)
+        # TODO: @cwolfe use response and at least debug log status
+        http.request req
       end
     end
 

--- a/lib/chef/telemetry/client.rb
+++ b/lib/chef/telemetry/client.rb
@@ -1,4 +1,5 @@
 require "net/http"
+require "uri"
 require "json"
 require "concurrent"
 
@@ -12,7 +13,9 @@ class Chef
       attr_reader :http
       def initialize(endpoint = TELEMETRY_ENDPOINT)
         super()
-        @http = Net::HTTP.new(endpoint)
+        uri = URI(endpoint)
+        @http = Net::HTTP.new(uri.host, uri.port)
+        @http.use_ssl = uri.scheme == "https"
         @http.start
       end
 

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -10,15 +10,17 @@ RSpec.describe Chef::Telemetry::Client do
 
   let(:telemetry_endpoint) { "https://my.telemetry.endpoint" }
   let(:event) { {} }
-  let(:http_mock) { double(HTTP, flush: true) }
 
   it "initializes the http client" do
-    expect(HTTP).to receive(:persistent).with(telemetry_endpoint)
+    net_http_mock = double(Net::HTTP)
+    expect(Net::HTTP).to receive(:new).with(telemetry_endpoint).and_return(net_http_mock)
+    expect(net_http_mock).to receive(:start)
     Chef::Telemetry::Client.new(telemetry_endpoint)
   end
 
   it "sends an event" do
-    expect(subject.http).to receive(:post).with("/events", hash_including(json: event)).and_return(http_mock)
+    response_mock = double(Net::HTTPResponse, status: 200)
+    expect(subject.http).to receive(:request).with(instance_of(Net::HTTP::Post)).and_return(response_mock)
     subject.fire(event)
   end
 end

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -13,8 +13,10 @@ RSpec.describe Chef::Telemetry::Client do
 
   it "initializes the http client" do
     net_http_mock = double(Net::HTTP)
-    expect(Net::HTTP).to receive(:new).with(telemetry_endpoint).and_return(net_http_mock)
-    expect(net_http_mock).to receive(:start)
+    uri = URI(telemetry_endpoint)
+    expect(Net::HTTP).to receive(:new).with(uri.host, uri.port).and_return(net_http_mock)
+    expect(net_http_mock).to receive(:use_ssl=).with(true)
+    expect(net_http_mock).to receive(:start).with(any_args)
     Chef::Telemetry::Client.new(telemetry_endpoint)
   end
 


### PR DESCRIPTION

<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
Uses the Ruby-included Net::HTTP instead of the rubygem HTTP, which has native extensions. For the type of work chef-telemetry is doing, we don't really need the performance boost, and we certainly don't need the extra dependency and compilation issues.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

Partial fix for #32
Closes https://github.com/chef/chef-workstation/issues/1200

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
