### PR TITLE
Remove redundant encoding comment

### DIFF
--- a/chef-telemetry.gemspec
+++ b/chef-telemetry.gemspec
@@ -1,4 +1,3 @@
-# coding: utf-8
 lib = File.expand_path("../lib", __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require "chef/telemetry/version"


### PR DESCRIPTION
utf-8 is the default in Ruby 2.0+

Signed-off-by: Tim Smith <tsmith@chef.io>