### PR TITLE
Optimize requires for non-omnibus installs

### DIFF
--- a/lib/chef/telemeter.rb
+++ b/lib/chef/telemeter.rb
@@ -16,13 +16,13 @@
 #
 
 require_relative "telemetry/version"
-require "benchmark"
-require "forwardable"
-require "singleton"
-require "json"
+require "benchmark" unless defined?(Benchmark)
+require "forwardable" unless defined?(Forwardable)
+require "singleton" unless defined?(Singleton)
+require "json" unless defined?(JSON)
 require "digest/sha1"
-require "securerandom"
-require "yaml"
+require "securerandom" unless defined?(SecureRandom)
+require "yaml" unless defined?(YAML)
 
 class Chef
   # This definites the Telemeter interface. Implementation thoughts for

--- a/lib/chef/telemetry/client.rb
+++ b/lib/chef/telemetry/client.rb
@@ -1,6 +1,6 @@
-require "net/http"
-require "uri"
-require "json"
+require "net/http" unless defined?(Net::HTTP)
+require "uri" unless defined?(URI)
+require "json" unless defined?(JSON)
 require "concurrent"
 
 class Chef

--- a/lib/chef/telemetry/session.rb
+++ b/lib/chef/telemetry/session.rb
@@ -1,4 +1,4 @@
-require "securerandom"
+require "securerandom" unless defined?(SecureRandom)
 require "chef-config/path_helper"
 
 class Chef


### PR DESCRIPTION
require is quite slow in Ruby and doing requires for things you've already required is also slow. We've used this simple hack in Chef to speed up our requires. In the omnibus installs we patch how rubygems works to make this somewhat pointless, but this will help non-omnibus installs

Signed-off-by: Tim Smith <tsmith@chef.io>