### PR TITLE
Remove unused ffi-yajl dep

### DIFF
--- a/chef-telemetry.gemspec
+++ b/chef-telemetry.gemspec
@@ -14,7 +14,6 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_development_dependency "bundler"
-  spec.add_dependency "ffi-yajl", "~> 2.2"
   spec.add_dependency "concurrent-ruby", "~> 1.0"
   spec.add_dependency "chef-config"
 end


### PR DESCRIPTION
We're using Ruby's built in JSON parser, which is ideal since we might
not be in an omnibus package

Signed-off-by: Tim Smith <tsmith@chef.io>