### PR TITLE
Fix failures on Ruby 3

### DIFF
--- a/.expeditor/verify.pipeline.yml
+++ b/.expeditor/verify.pipeline.yml
@@ -33,6 +33,15 @@ steps:
       docker:
         image: ruby:2.7-buster
 
+- label: run-lint-and-specs-ruby-3.0
+  command:
+    - bundle install --jobs=7 --retry=3 --without docs debug
+    - bundle exec rake
+  expeditor:
+    executor:
+      docker:
+        image: ruby:3.0-buster
+
 - label: run-specs-windows
   command:
     - bundle install --jobs=7 --retry=3 --without docs debug

--- a/Gemfile
+++ b/Gemfile
@@ -6,19 +6,12 @@ gemspec
 group :debug do
   gem "pry"
   gem "pry-byebug"
-  gem "pry-stack_explorer"
 end
 
 group :test do
   gem "chefstyle", "1.7.5"
   gem "rake"
   gem "rspec", "~> 3.0"
-end
-
-group :docs do
-  gem "github-markup"
-  gem "redcarpet"
-  gem "yard"
 end
 
 if Gem.ruby_version < Gem::Version.new("2.6")

--- a/Rakefile
+++ b/Rakefile
@@ -21,13 +21,6 @@ rescue LoadError
   puts "chefstyle gem is not installed. bundle install first to make sure all dependencies are installed."
 end
 
-begin
-  require "yard" unless defined?(YARD)
-  YARD::Rake::YardocTask.new(:docs)
-rescue LoadError
-  puts "yard is not available. bundle install first to make sure all dependencies are installed."
-end
-
 task :console do
   require "irb"
   require "irb/completion"

--- a/lib/chef/telemeter/sender.rb
+++ b/lib/chef/telemeter/sender.rb
@@ -66,6 +66,7 @@ class Chef
           Telemeter::Log.info("Telemetry disabled, clearing any existing session captures without sending them.")
           session_files.each { |path| FileUtils.rm_rf(path) }
         end
+        require "fileutils" unless defined?(FileUtils)
         FileUtils.rm_rf(config[:session_file])
         Telemeter::Log.info("Terminating, nothing more to do.")
       rescue => e

--- a/lib/chef/telemetry/session.rb
+++ b/lib/chef/telemetry/session.rb
@@ -1,4 +1,5 @@
 require "securerandom" unless defined?(SecureRandom)
+require "fileutils" unless defined?(FileUtils)
 require "chef-config/path_helper"
 
 class Chef

--- a/spec/session_spec.rb
+++ b/spec/session_spec.rb
@@ -11,8 +11,8 @@ RSpec.describe Chef::Telemetry::Session do
   before do
     allow(ChefConfig::PathHelper).to receive(:home).with(".chef").and_return(File.join(home, ".chef"))
     allow(SecureRandom).to receive(:uuid).and_return(new_uuid)
-    expect(FileUtils).to receive(:touch).with(session_path).and_return true
-    allow(FileUtils).to receive(:mkdir_p).with(File.dirname(session_path)).and_return true
+    expect(::FileUtils).to receive(:touch).with(session_path).and_return true
+    allow(::FileUtils).to receive(:mkdir_p).with(File.dirname(session_path)).and_return true
 
     allow(File).to receive(:stat).with(session_path).and_return(stat_mock)
     allow(File).to receive(:open).with(session_path, "w").and_yield(write_mock)

--- a/spec/telemeter/sender_spec.rb
+++ b/spec/telemeter/sender_spec.rb
@@ -59,9 +59,9 @@ RSpec.describe Chef::Telemeter::Sender do
     context "when telemetry is disabled" do
       let(:enabled_flag) { false }
       it "deletes session files without sending" do
-        expect(FileUtils).to receive(:rm_rf).with("file1")
-        expect(FileUtils).to receive(:rm_rf).with("file2")
-        expect(FileUtils).to receive(:rm_rf).with(config[:session_file])
+        expect(::FileUtils).to receive(:rm_rf).with("file1")
+        expect(::FileUtils).to receive(:rm_rf).with("file2")
+        expect(::FileUtils).to receive(:rm_rf).with(config[:session_file])
         expect(subject).to_not receive(:process_session)
         subject.run
       end
@@ -123,7 +123,7 @@ RSpec.describe Chef::Telemeter::Sender do
   describe "submit_session" do
     let(:telemetry) { instance_double("telemetry") }
     it "removes the telemetry session file and starts a new session, then submits each entry in the session" do
-      expect(FileUtils).to receive(:rm_rf).with(config[:session_file])
+      expect(::FileUtils).to receive(:rm_rf).with(config[:session_file])
       expect(Chef::Telemetry).to receive(:new).and_return telemetry
       expect(subject).to receive(:submit_entry).with(telemetry, { "event" => "action1" }, 1, 2)
       expect(subject).to receive(:submit_entry).with(telemetry, { "event" => "action2" }, 2, 2)


### PR DESCRIPTION
fileutils isn't coming for free anymore in Ruby 3 it appears. Make sure we actually require it.

Signed-off-by: Tim Smith <tsmith@chef.io>
