### PR TITLE
Drop support for Ruby 2.4 and 2.5

### DIFF
--- a/.expeditor/verify.pipeline.yml
+++ b/.expeditor/verify.pipeline.yml
@@ -6,24 +6,6 @@ expeditor:
 
 steps:
 
-- label: run-lint-and-specs-ruby-2.4
-  command:
-    - bundle install --jobs=7 --retry=3 --without docs debug
-    - bundle exec rake
-  expeditor:
-    executor:
-      docker:
-        image: ruby:2.4-stretch
-
-- label: run-lint-and-specs-ruby-2.5
-  command:
-    - bundle install --jobs=7 --retry=3 --without docs debug
-    - bundle exec rake
-  expeditor:
-    executor:
-      docker:
-        image: ruby:2.5-stretch
-
 - label: run-lint-and-specs-ruby-2.6
   command:
     - bundle install --jobs=7 --retry=3 --without docs debug

--- a/chef-telemetry.gemspec
+++ b/chef-telemetry.gemspec
@@ -13,6 +13,7 @@ Gem::Specification.new do |spec|
   spec.files         = %w{LICENSE} + Dir.glob("lib/**/*")
   spec.require_paths = ["lib"]
 
+  spec.required_ruby_version = ">= 2.6"
   spec.add_development_dependency "bundler"
   spec.add_dependency "concurrent-ruby", "~> 1.0"
   spec.add_dependency "chef-config"


### PR DESCRIPTION
Both of these releases are now EOL

Signed-off-by: Tim Smith <tsmith@chef.io>