### PR TITLE
[INFC-138] Fixed the verify pipeline failures

### DIFF
--- a/.expeditor/verify.pipeline.yml
+++ b/.expeditor/verify.pipeline.yml
@@ -6,26 +6,6 @@ expeditor:
 
 steps:
 
-- label: run-lint-and-specs-ruby-2.5
-  command:
-    - bundle config set --local without docs debug
-    - bundle install --jobs=7 --retry=3
-    - bundle exec rake
-  expeditor:
-    executor:
-      docker:
-        image: ruby:2.5
-
-- label: run-lint-and-specs-ruby-2.6
-  command:
-    - bundle config set --local without docs debug
-    - bundle install --jobs=7 --retry=3
-    - bundle exec rake
-  expeditor:
-    executor:
-      docker:
-        image: ruby:2.6
-
 - label: run-lint-and-specs-ruby-2.7
   command:
     - bundle config set --local without docs debug

--- a/chef-telemetry.gemspec
+++ b/chef-telemetry.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |spec|
   spec.files         = %w{LICENSE} + Dir.glob("lib/**/*")
   spec.require_paths = ["lib"]
 
-  spec.required_ruby_version = ">= 2.5"
+  spec.required_ruby_version = ">= 2.7"
   spec.add_dependency "concurrent-ruby", "~> 1.0"
   spec.add_dependency "chef-config"
 end

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -10,6 +10,7 @@ RSpec.describe Chef::Telemetry::Client do
 
   let(:telemetry_endpoint) { "https://my.telemetry.endpoint" }
   let(:event) { {} }
+  let(:default_endpoint) { "https://telemetry.chef.io" }
 
   it "initializes the http client" do
     net_http_mock = double(Net::HTTP)
@@ -21,6 +22,10 @@ RSpec.describe Chef::Telemetry::Client do
   end
 
   it "sends an event" do
+    net_http_mock = double(Net::HTTP, 'use_ssl=': true, start: true)
+    uri = URI(default_endpoint)
+    allow(Net::HTTP).to receive(:new).with(uri.host, uri.port).and_return(net_http_mock)
+
     response_mock = double(Net::HTTPResponse, status: 200)
     expect(subject.http).to receive(:request).with(instance_of(Net::HTTP::Post)).and_return(response_mock)
     subject.fire(event)

--- a/spec/telemetry_spec.rb
+++ b/spec/telemetry_spec.rb
@@ -29,8 +29,13 @@ RSpec.describe Chef::Telemetry do
   end
 
   describe "opted in" do
+    let(:default_endpoint) { "https://telemetry.chef.io" }
+
     before do
       expect(Chef::Telemetry::Decision).to receive(:opt_out?).and_return(false)
+      net_http_mock = double(Net::HTTP, 'use_ssl=': true, start: true, request: {})
+      uri = URI(default_endpoint)
+      allow(Net::HTTP).to receive(:new).with(uri.host, uri.port).and_return(net_http_mock)
     end
 
     it "sends an event" do


### PR DESCRIPTION
Signed-off-by: Ashique P S <Ashique.saidalavi@progress.com>

<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
There are two specs where the tests are accessing the `chef.telemetry.io`. Those specs failed when that service was down. It is not a good practice to have external net connections inside the specs. I've added the Net::HTTP mock to block those external requests. 

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
