### PR TITLE
CHEF-27266 - standardize - remove_sla_from_readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,14 +3,6 @@
 [![Gem Version](https://badge.fury.io/rb/chef-telemetry.svg)](https://rubygems.org/gems/chef-telemetry)
 [![Build status](https://badge.buildkite.com/7eede2e516f4a2db2fa0091f39f60da51dd44d37e27fab9fc2.svg?branch=master)](https://buildkite.com/chef-oss/chef-chef-telemetry-master-verify)
 
-**Umbrella Project**: [Chef Foundation](https://github.com/chef/chef-oss-practices/blob/master/projects/chef-foundation.md)
-
-**Project State**: [Active](https://github.com/chef/chef-oss-practices/blob/master/repo-management/repo-states.md#active)
-
-**Issues [Response Time Maximum](https://github.com/chef/chef-oss-practices/blob/master/repo-management/repo-states.md)**: 14 days
-
-**Pull Request [Response Time Maximum](https://github.com/chef/chef-oss-practices/blob/master/repo-management/repo-states.md)**: 14 days
-
 A gem to send telemetry data per Chef's [RFC-051](https://github.com/chef/chef-rfc/blob/master/rfc051-telemetry.md)
 
 ## Installation


### PR DESCRIPTION
This pull request removes the oft-misleading Chef SLA text from the README.md file.
This action is being taken as part of the [2025 Repo Standardization Initiative](https://github.com/chef-boneyard/oss-repo-standardization-2025). 
As Progress Chef makes a best effort to respond to issues and pull requests in a timely manner, and prioritizes bugfixes and security updates on a customer-driven basis (which may span repos, or have no repo footprint at all), we no longer support the concept of a Service Level Agreement (SLA) on a repository-centric basis. For further details, see [Repo SLA Removal FAQ](https://github.com/chef-boneyard/oss-repo-standardization-2025/blob/main/messaging/sla-removal.md).
